### PR TITLE
[SYM-4112] Fix typo Datadog example

### DIFF
--- a/datadog_log_destination/main.tf
+++ b/datadog_log_destination/main.tf
@@ -34,7 +34,7 @@ resource "sym_integration" "runtime_context" {
 
 # This module creates a AWS Kinesis Firehose Delivery Stream that pipes logs to Datadog
 module "datadog_connector" {
-  source  = "symopsio/datadog_connector/sym"
+  source  = "symopsio/datadog-connector/sym"
   version = ">= 1.0.2"
 
   environment = "main"


### PR DESCRIPTION
# Summary
The Datadog example has a typo in the module name, the correct module name is `symopsio/datadog-connector/sym`