### PR TITLE
[SYM-4248] Update GitHub dynamic targets example to use prefetch

### DIFF
--- a/github_dynamic_targets/README.md
+++ b/github_dynamic_targets/README.md
@@ -2,7 +2,7 @@
 
 This example illustrates how to configure a GitHub Strategy that uses Dynamic Access Targets to allow requesters to input the repository they wish to access.
 
-https://user-images.githubusercontent.com/10479740/178318567-83eca8d4-3def-40d0-a506-dfd2db81f867.mov
+https://user-images.githubusercontent.com/10479740/200004614-e1a73240-260c-4fb4-a24c-5a3c267242c3.mov
 
 ## Tutorial
 

--- a/github_dynamic_targets/impl.py
+++ b/github_dynamic_targets/impl.py
@@ -22,7 +22,7 @@ def get_repos(event):
 
     # Use the GitHub API to get the first 100 public repos in the Symopsio organization
     response = requests.get(
-        url="https://api.github.com/orgs/symopsio/repos?per_page=100&type=public",
+        url="https://api.github.com/orgs/sym-test/repos?per_page=100&type=private",
         headers=headers
     )
     if not response.ok:

--- a/github_dynamic_targets/impl.py
+++ b/github_dynamic_targets/impl.py
@@ -1,5 +1,7 @@
-from sym.sdk.annotations import reducer
+from sym.sdk.annotations import reducer, prefetch
 from sym.sdk.integrations import slack
+from sym.sdk.field_option import FieldOption
+import requests
 
 
 # Reducers fill in the blanks that your workflow needs in order to run.
@@ -9,3 +11,25 @@ def get_approvers(event):
 
     # allow_self lets the requester approve themself, which is great for testing!
     return slack.channel("#sym-requests", allow_self=True)
+
+
+# Prefetch reducers return a list of FieldOptions that will be used to populate
+# the Slack select menu for the Prompt Field with the given "field_name"
+@prefetch(field_name="repo_name")
+def get_repos(event):
+    github_token = event.flow.environment.integrations["github"].settings["api_token_secret"].retrieve_value()
+    headers = {"Authorization": f"Token {github_token}"}
+
+    # Use the GitHub API to get the first 100 public repos in the Symopsio organization
+    response = requests.get(
+        url="https://api.github.com/orgs/symopsio/repos?per_page=100&type=public",
+        headers=headers
+    )
+    if not response.ok:
+        raise RuntimeError(f"Failed to query repos from GitHub. Status code: {response.status_code}.")
+
+    # For this example, the value and the label are the same for the options.
+    # Return a list of all the repos in the API response.
+    return [
+        FieldOption(value=repo["name"], label=repo["name"]) for repo in response.json()
+    ]

--- a/github_dynamic_targets/main.tf
+++ b/github_dynamic_targets/main.tf
@@ -86,8 +86,8 @@ resource "sym_integration" "github" {
 resource "sym_target" "private-repo" {
   type = "github_repo"
 
-  name  = "public-repos"
-  label = "Public Repos"
+  name  = "private-repos"
+  label = "Private Repos"
 
   # A special attribute indicating which settings will be dynamically populated by prompt fields.
   # In this case, the setting is the required `repo_name` setting. The value will be populated by the

--- a/github_dynamic_targets/main.tf
+++ b/github_dynamic_targets/main.tf
@@ -86,12 +86,12 @@ resource "sym_integration" "github" {
 resource "sym_target" "private-repo" {
   type = "github_repo"
 
-  name  = "private-repos"
-  label = "Private Repos"
+  name  = "public-repos"
+  label = "Public Repos"
 
   # A special attribute indicating which settings will be dynamically populated by prompt fields.
   # In this case, the setting is the required `repo_name` setting. The value will be populated by the
-  # `repo_name` field in the `sym_flow.params.prompt_fields_json` attribute.
+  # `repo_name` field in the `sym_flow.params.prompt_fields` attribute.
   field_bindings = ["repo_name"]
 }
 
@@ -126,6 +126,10 @@ resource "sym_flow" "this" {
       label    = "Repository Name"
       type     = "string"
       required = true
+
+      # Setting prefetch = true means that this field's allowed values will be populated by
+      # a prefetch reducer defined in the impl.py
+      prefetch = true
     }
 
     prompt_field {


### PR DESCRIPTION
# Summary
- Updates the GitHub dynamic targets example to make the `repo_name` Prompt Field `prefetch = True`
- Implements a prefetch function that shows how to make an API request and return a list of FieldOptions


https://user-images.githubusercontent.com/10479740/200004614-e1a73240-260c-4fb4-a24c-5a3c267242c3.mov

