### PR TITLE
[SYM-4419] Update approvals example to use sym_org_id instead of slug

### DIFF
--- a/approvals/main.tf
+++ b/approvals/main.tf
@@ -1,5 +1,5 @@
 provider "sym" {
-  org = var.sym_org_slug
+  org = var.sym_org_id
 }
 
 resource "sym_flow" "this" {

--- a/approvals/terraform.tfvars
+++ b/approvals/terraform.tfvars
@@ -1,4 +1,4 @@
-sym_org_slug       = "CHANGEME"
+sym_org_id         = "CHANGEME"
 slack_workspace_id = "CHANGEME"
 
 flow_variables = {

--- a/approvals/variables.tf
+++ b/approvals/variables.tf
@@ -22,7 +22,7 @@ variable "slack_workspace_id" {
 }
 
 variable "sym_org_id" {
-  description = "ID for your organization in Sym."
+  description = "ID for your organization in Sym. (e.g. `S-VJ2IYOCQ74`)"
   type        = string
 }
 

--- a/approvals/variables.tf
+++ b/approvals/variables.tf
@@ -21,8 +21,8 @@ variable "slack_workspace_id" {
   type        = string
 }
 
-variable "sym_org_slug" {
-  description = "Uniquely identifying slug for your organization in Sym."
+variable "sym_org_id" {
+  description = "ID for your organization in Sym."
   type        = string
 }
 


### PR DESCRIPTION
Organization Slug -> ID. This should go out with v4.0 of the docs.

