### PR TITLE
[SYM-4688] Fix AWS SSO Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ builds/
 
 .idea/*
 .vscode/*
+**/.DS_Store

--- a/basic/aws_sso_strategy/aws_sso_strategy.tf
+++ b/basic/aws_sso_strategy/aws_sso_strategy.tf
@@ -26,7 +26,7 @@ module "sso_connector" {
     aws = aws.sso
   }
 
-  environment       = "main"
+  environment = local.environment_name
 
   # The aws_iam_role.sym_runtime_connector_role resource is defined in `runtime.tf`
   runtime_role_arns = [aws_iam_role.sym_runtime_connector_role.arn]

--- a/basic/aws_sso_strategy/aws_sso_strategy.tf
+++ b/basic/aws_sso_strategy/aws_sso_strategy.tf
@@ -26,7 +26,7 @@ module "sso_connector" {
     aws = aws.sso
   }
 
-  environment = local.environment_name
+  environment = "main"
 
   # The aws_iam_role.sym_runtime_connector_role resource is defined in `runtime.tf`
   runtime_role_arns = [aws_iam_role.sym_runtime_connector_role.arn]

--- a/basic/aws_sso_strategy/runtime.tf
+++ b/basic/aws_sso_strategy/runtime.tf
@@ -101,3 +101,23 @@ resource "sym_runtime" "this" {
   # Give the Sym Runtime the permissions defined by the runtime_context resource.
   context_id = sym_integration.runtime_context.id
 }
+
+resource "aws_iam_policy" "sso_assume_roles" {
+  name = "${local.role_name}_SSOAssumeRoles"
+  path = "/sym/"
+
+  description = "This policy allows the Sym Runtime to assume roles in the /sym/ path in your AWS SSO account."
+  policy = jsonencode({
+    Statement = [{
+      Action   = "sts:AssumeRole"
+      Effect   = "Allow"
+      Resource = ["arn:aws:iam::${data.aws_caller_identity.sso.account_id}:role/sym/*"]
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_assume_roles_sso" {
+  policy_arn = aws_iam_policy.sso_assume_roles.arn
+  role       = aws_iam_role.sym_runtime_connector_role.name
+}


### PR DESCRIPTION
# Summary
- Adds a missing AWS IAM Policy that allows the Runtime Connector Role to assume roles in the SSO Account
